### PR TITLE
[refactor] allow Representative model to handle existing representatives

### DIFF
--- a/app/models/representative.rb
+++ b/app/models/representative.rb
@@ -17,7 +17,7 @@ class Representative < ApplicationRecord
         end
       end
 
-      rep = Representative.create!({ name: official.name, ocdid: ocdid_temp,
+      rep = Representative.find_or_create_by!({ name: official.name, ocdid: ocdid_temp,
           title: title_temp })
       reps.push(rep)
     end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SearchController, type: :controller do
+  describe 'GET search' do
+    before do
+      @fake_response = instance_double(Google::Apis::CivicinfoV2::RepresentativeInfoResponse)
+      @fake_address = 'fake address'
+      @fake_service = instance_double(Google::Apis::CivicinfoV2::CivicInfoService)
+
+      allow(Google::Apis::CivicinfoV2::CivicInfoService).to receive(:new).and_return(@fake_service)
+      allow(@fake_service).to receive(:representative_info_by_address).and_return(@fake_response)
+      allow(@fake_service).to receive(:key=)
+      allow(Rails.application.credentials).to receive(:[]).with(:GOOGLE_API_KEY).and_return('mock_api_key')
+      allow(Representative).to receive(:civic_api_to_representative_params).with(@fake_response)
+    end
+
+    it 'gets representative info with the provided address' do
+      get :search, params: { address: @fake_address }
+      expect(@fake_service).to have_received(:representative_info_by_address).with(address: @fake_address)
+    end
+
+    it 'renders the representatives/search template' do
+      get :search, params: { address: @fake_address }
+      expect(response).to render_template('representatives/search')
+    end
+  end
+end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -12,7 +12,7 @@ describe SearchController, type: :controller do
       allow(Google::Apis::CivicinfoV2::CivicInfoService).to receive(:new).and_return(@fake_service)
       allow(@fake_service).to receive(:representative_info_by_address).and_return(@fake_response)
       allow(@fake_service).to receive(:key=)
-      allow(Rails.application.credentials).to receive(:[]).with(:GOOGLE_API_KEY).and_return('mock_api_key')
+      allow(Rails.application.credentials).to receive(:[]).with(:GOOGLE_API_KEY)
       allow(Representative).to receive(:civic_api_to_representative_params).with(@fake_response)
     end
 

--- a/spec/models/representative_spec.rb
+++ b/spec/models/representative_spec.rb
@@ -7,11 +7,10 @@ describe Representative, type: :model do
     before do
       @rep_info = instance_double(Google::Apis::CivicinfoV2::RepresentativeInfoResponse)
       @existing_representative = described_class.create(name: 'name', ocdid: 0, title: 'title')
-      @new_representative = OpenStruct.new(name: 'new name', ocdid: 1, title: 'new title')
       allow(described_class).to receive(:create!).and_call_original
     end
 
-    context 'when representative already in database' do
+    context 'when representative is already in database' do
       before do
         allow(@rep_info).to receive(:officials).and_return([OpenStruct.new(name: @existing_representative.name)])
         offices_object = OpenStruct.new(name: @existing_representative.title,
@@ -26,8 +25,9 @@ describe Representative, type: :model do
       end
     end
 
-    context 'when representative not in database' do
+    context 'when searching for a new representative' do
       before do
+        @new_representative = OpenStruct.new(name: 'new name', ocdid: 1, title: 'new title')
         allow(@rep_info).to receive(:officials).and_return([OpenStruct.new(name: @new_representative.name)])
         new_offices_object = OpenStruct.new(name: @new_representative.title,
                                             division_id: @new_representative.ocdid, official_indices: [0])

--- a/spec/models/representative_spec.rb
+++ b/spec/models/representative_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Representative, type: :model do
+  describe '.civic_api_to_representative_params' do
+    before do
+      @rep_info = instance_double(Google::Apis::CivicinfoV2::RepresentativeInfoResponse)
+      @existing_representative = described_class.create(name: 'name', ocdid: 0, title: 'title')
+      @new_representative = OpenStruct.new(name: 'new name', ocdid: 1, title: 'new title')
+      allow(described_class).to receive(:create!).and_call_original
+    end
+
+    context 'when representative already in database' do
+      before do
+        allow(@rep_info).to receive(:officials).and_return([OpenStruct.new(name: @existing_representative.name)])
+        offices_object = OpenStruct.new(name: @existing_representative.title,
+                                        division_id: @existing_representative.ocdid, official_indices: [0])
+        allow(@rep_info).to receive(:offices).and_return([offices_object])
+      end
+
+      it 'does not create a new representative' do
+        expect do
+          described_class.civic_api_to_representative_params(@rep_info)
+        end.not_to change(described_class, :count)
+      end
+    end
+
+    context 'when representative not in database' do
+      before do
+        allow(@rep_info).to receive(:officials).and_return([OpenStruct.new(name: @new_representative.name)])
+        new_offices_object = OpenStruct.new(name: @new_representative.title,
+                                            division_id: @new_representative.ocdid, official_indices: [0])
+        allow(@rep_info).to receive(:offices).and_return([new_offices_object])
+      end
+
+      it 'creates a new representative' do
+        expect do
+          described_class.civic_api_to_representative_params(@rep_info)
+        end.to change(described_class, :count).by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
1. refactors Representative model to find a representative that already exists in the database, otherwise create one
2. adds specs for SearchController and Representative model